### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.2] - 2026-04-05
+
+### Fixed
+- Allow keyboard-triggered suggest widget (Ctrl+Space IntelliSense) to display correctly while cursor is hidden
+- Narrow Layer 3 CSS to only target `.monaco-tooltip` instead of blanket-hiding all `overflowingContentWidgets` children
+- Suppress `.monaco-sash` hover highlight persistence when cursor is hidden
+
+### Changed
+- Extend overlay exemptions with `.suggest-widget`, `.suggest-details-container`, and `.parameter-hints-widget`
+- Refactor JS `overlayWatcher` to monitor `.suggest-widget` display changes alongside `.quick-input-widget`
+
 ## [0.1.1] - 2026-03-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cursor-auto-hide",
   "displayName": "Cursor Auto Hide",
   "description": "Automatically hides the mouse cursor after N seconds of inactivity. Perfect for Vim/Neovim users who prefer keyboard-only navigation.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "j4rviscmd",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

Release v0.1.2 — patch release with a fix for keyboard-triggered suggest widget display.

## Changes since v0.1.1

### Fixed
- Allow keyboard-triggered suggest widget (Ctrl+Space IntelliSense) to display correctly while cursor is hidden
- Narrow Layer 3 CSS to only target `.monaco-tooltip` instead of blanket-hiding all `overflowingContentWidgets` children
- Suppress `.monaco-sash` hover highlight persistence when cursor is hidden

### Changed
- Extend overlay exemptions with `.suggest-widget`, `.suggest-details-container`, and `.parameter-hints-widget`
- Refactor JS `overlayWatcher` to monitor `.suggest-widget` display changes alongside `.quick-input-widget`

## Version Bump
- `package.json`: 0.1.1 → 0.1.2
- `CHANGELOG.md`: Updated with v0.1.2 entry